### PR TITLE
Improve fetch_streams error message

### DIFF
--- a/YTDownloader.py
+++ b/YTDownloader.py
@@ -27,7 +27,13 @@ def fetch_streams():
         resolution_combo['values'] = [stream.resolution for stream in streams]
         resolution_combo.current(0)
     except Exception as e:
-        messagebox.showerror("Error", f"Failed to fetch video streams: {e}")
+        # Log the real error to the terminal for debugging purposes
+        print(f"Failed to fetch video streams: {e}")
+        # Show a user-friendly message in the popup dialog
+        messagebox.showerror(
+            "Error",
+            "This video might be private, restricted, region-locked, or unsupported. Try a different one."
+        )
 
 def download_video():
     selected_stream = stream_list[resolution_combo.current()]


### PR DESCRIPTION
## Summary
- show a friendlier error message when fetching streams fails
- log the real error message to the terminal

## Testing
- `python -m py_compile YTDownloader.py`

------
https://chatgpt.com/codex/tasks/task_e_68460e9f21b483289dac480cce8b2b25