### PR TITLE
Improve fallback and error handling

### DIFF
--- a/YTDownloader.py
+++ b/YTDownloader.py
@@ -48,16 +48,24 @@ def download_video():
     # Build yt-dlp command: best MP4 video + best M4A audio, merge into MP4
     cmd = [
         "yt-dlp",
-        "-f", "bestvideo[ext=mp4]+bestaudio[ext=m4a]",
-        "--merge-output-format", "mp4",
-        "-o", f"{directory}/%(title)s.%(ext)s",
+        "-f",
+        "bestvideo[ext=mp4]+bestaudio[ext=m4a]/bestvideo+bestaudio",
+        "--remux-video",
+        "mp4",
+        "-o",
+        f"{directory}/%(title)s.%(ext)s",
         url,
     ]
     try:
         subprocess.run(cmd, check=True)
         messagebox.showinfo("Success", "Download completed!")
     except subprocess.CalledProcessError as e:
-        messagebox.showerror("Error", f"yt-dlp failed: {e}")
+        messagebox.showerror(
+            "Download Failed",
+            "Couldn\u2019t assemble an mp4+audio combo. "
+            "Try a different video/resolution or install ffmpeg.\n"
+            f"(exit code {e.returncode})",
+        )
 
 # Create the main window
 root = tk.Tk()


### PR DESCRIPTION
## Summary
- update yt-dlp format selection logic to allow fallback
- remux final output to mp4
- show friendlier error message when yt-dlp fails

## Testing
- `python3 -m py_compile YTDownloader.py`

------
https://chatgpt.com/codex/tasks/task_e_6846205a3b008328b72ebb7f7bf2e016