### PR TITLE
Add theme menu and improved progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ Your go-to, no-fuss YouTube video downloader built with Python and a sprinkle of
 
 * **Easy GUI**: Simple input field + dropdown for resolution.
 * **Multiple Resolutions**: Grab videos in 360p, 720p, 1080p, and more.
-* **Progress Bar**: Watch your download zoom to completion.
+* **Progress Bar**: Watch MB progress update in real time while downloading.
 * **Error Handling**: Friendly popups guide you if something’s off.
 * **Cross-Platform**: Runs on macOS, Windows, and Linux (with Python 3).
+* **Theme Menu**: Quickly preview any ttkbootstrap theme.
+* **Right-Click Paste**: Use the URL box’s context menu for easy pasting.
 
 ---
 


### PR DESCRIPTION
## Summary
- allow right-click paste in the URL entry
- add a themes menu for changing ttkbootstrap theme
- run downloads in a background thread so the UI stays responsive
- show MB progress with a label under the progress bar
- document the new options in the README

## Testing
- `python -m py_compile YTDownloader.py`

------
https://chatgpt.com/codex/tasks/task_e_684633173068832896ae97558846104a